### PR TITLE
update to new chds naming conventions

### DIFF
--- a/include/cecs/component.h
+++ b/include/cecs/component.h
@@ -58,8 +58,8 @@ typedef struct
 {
     ComponentsBitset bitset;
 
-    // TODO: Vector?
-    // TODO: If we use a vector then some sort of shrink to fit function
+    // TODO: chds_vec?
+    // TODO: If we use a chds_vec then some sort of shrink to fit function
     //       could be nice, unless we can reserve before??
     int num_components;
     ComponentInfo* infos;

--- a/src/archetype.c
+++ b/src/archetype.c
@@ -16,7 +16,7 @@ void Archetype_destroy(Archetype* archetype)
         free(archetype->columns[i]);
     }
 
-    Vector_destroy(archetype->index_to_entity);
+    chds_vec_destroy(archetype->index_to_entity);
 
     archetype = 0;
 }

--- a/src/archetype_internal.h
+++ b/src/archetype_internal.h
@@ -6,7 +6,7 @@
 #include "entity.h"
 #include "component.h"
 
-#include <chds/vector.h>
+#include <chds/vec.h>
 
 // Stores columns for entities matching a signature.
 typedef struct Archetype
@@ -14,7 +14,7 @@ typedef struct Archetype
     ComponentsSignature signature;
 
     // TODO: Some sort of map?
-    Vector(EntityID) index_to_entity;
+    chds_vec(EntityID) index_to_entity;
 
     void** columns;
 

--- a/src/ecs_internal.h
+++ b/src/ecs_internal.h
@@ -3,7 +3,7 @@
 
 #include "ecs.h"
 
-#include <chds/vector.h>
+#include <chds/vec.h>
 
 typedef struct
 {
@@ -26,9 +26,9 @@ typedef struct ECS
     // archetype.
     EntityIndex* entity_indices;
 
-    Vector(ComponentInfo) component_infos;
-    Vector(Archetype) archetypes;
-    Vector(View) views;
+    chds_vec(ComponentInfo) component_infos;
+    chds_vec(Archetype) archetypes;
+    chds_vec(View) views;
 
 } ECS;
 

--- a/src/view.c
+++ b/src/view.c
@@ -3,5 +3,5 @@
 void View_destroy(View* view)
 {
     // TODO: Some ECS_destroy_view should probs call this.
-    Vector_destroy(view->archetype_ids);
+    chds_vec_destroy(view->archetype_ids);
 }

--- a/src/view_internal.h
+++ b/src/view_internal.h
@@ -5,11 +5,11 @@
 
 #include "component.h"
 
-#include <chds/vector.h>
+#include <chds/vec.h>
 
 typedef struct View
 {
-    Vector(ArchetypeID) archetype_ids;
+    chds_vec(ArchetypeID) archetype_ids;
 
     // TODO: Document
     ComponentsBitset include;


### PR DESCRIPTION
CHDS has converted from PascalCase to snake_case types. Update to work with this convention, next will be updating this lib naming conventions.