### PR TITLE
Swap naming convention to c style snake_case

### DIFF
--- a/examples/main.c
+++ b/examples/main.c
@@ -51,7 +51,7 @@ static void test_func(cecs_t* ecs, cecs_view_id_t view_id)
 
 int main()
 {
-    cecs_t* ecs = cesc_create();
+    cecs_t* ecs = cecs_create();
     
     position_component = cecs_regsiter_component(ecs, sizeof(Position));
     velocity_component = cecs_regsiter_component(ecs, sizeof(Velocity));

--- a/examples/main.c
+++ b/examples/main.c
@@ -8,9 +8,9 @@
 // TODO: Get a better example working, how can we define components.. - this cannot be done at compile time i believe.
 
 // TODO: How do we fix this.
-ComponentID position_component;
-ComponentID velocity_component;
-ComponentID health_component;
+cecs_component_id_t position_component;
+cecs_component_id_t velocity_component;
+cecs_component_id_t health_component;
 
 typedef struct
 {
@@ -28,14 +28,13 @@ typedef struct
     int max;
 } Health;
 
-static void test_func(ECS* ecs, ViewID view_id)
+static void test_func(cecs_t* ecs, cecs_view_id_t view_id)
 {
-    // TODO: I don't really like the name of these functions.
-    ViewIter it = ECS_view_iter(ecs, view_id);
-    while (ECS_view_iter_next(&it))
+    cecs_view_iter_t it = cecs_view_iter(ecs, view_id);
+    while (cecs_view_iter_next(&it))
     {
-        Position* positions = ECS_get_column(it, position_component);
-        Velocity* velocities = ECS_get_column(it, velocity_component);
+        Position* positions = cecs_get_column(it, position_component);
+        Velocity* velocities = cecs_get_column(it, velocity_component);
 
         for (uint32_t i = 0; i < it.num_entities; ++i)
         {
@@ -52,49 +51,49 @@ static void test_func(ECS* ecs, ViewID view_id)
 
 int main()
 {
-    ECS* ecs = ECS_create();
+    cecs_t* ecs = cesc_create();
     
-    position_component = ECS_register_component(ecs, sizeof(Position));
-    velocity_component = ECS_register_component(ecs, sizeof(Velocity));
-    health_component = ECS_register_component(ecs, sizeof(Health));
+    position_component = cecs_regsiter_component(ecs, sizeof(Position));
+    velocity_component = cecs_regsiter_component(ecs, sizeof(Velocity));
+    health_component = cecs_regsiter_component(ecs, sizeof(Health));
 
     // Register a test view that uses position, velocity but excludes health.
-    ViewID test_view_id = ECS_view(ecs,
-        COMPONENT_ID_TO_BITSET(position_component) | COMPONENT_ID_TO_BITSET(velocity_component),
-        COMPONENT_ID_TO_BITSET(health_component)
+    cecs_view_id_t test_view_id = cecs_view(ecs,
+        CECS_COMPONENT_ID_TO_BITSET(position_component) | CECS_COMPONENT_ID_TO_BITSET(velocity_component),
+        CECS_COMPONENT_ID_TO_BITSET(health_component)
     );
-    test_func(ecs, test_view_id);
 
     // TODO: Document how component pointers are only valid until the 
     //       next component is added!! or like how it actually works....
-    EntityID e0 = ECS_create_entity(ecs);
+    cecs_entity_id_t e0 = cecs_create_entity(ecs);
 
-    Position* e0_pos = ECS_add_component(ecs, e0, position_component);
+    Position* e0_pos = cecs_add_component(ecs, e0, position_component);
     e0_pos->x = 1;
     e0_pos->y = 1;
     e0_pos->z = 1;
 
-    Velocity* e0_vel = ECS_add_component(ecs, e0, velocity_component);
+    Velocity* e0_vel = cecs_add_component(ecs, e0, velocity_component);
     e0_vel->vx = -1;
     e0_vel->vy = -1;
     e0_vel->vz = -1;
 
-    ECS_remove_component(ecs, e0, velocity_component);
+    cecs_remove_component(ecs, e0, velocity_component);
     
-    EntityID e1 = ECS_create_entity(ecs);
-    ECS_add_component(ecs, e1, velocity_component);
-    ECS_add_component(ecs, e1, position_component);
-    ECS_add_component(ecs, e1, health_component);
+    cecs_entity_id_t e1 = cecs_create_entity(ecs);
+    cecs_add_component(ecs, e1, velocity_component);
+    cecs_add_component(ecs, e1, position_component);
+    cecs_add_component(ecs, e1, health_component);
 
-    ECS_remove_component(ecs, e1, health_component);
-    ECS_remove_component(ecs, e1, velocity_component);
-    ECS_remove_component(ecs, e1, position_component);
+    cecs_remove_component(ecs, e1, health_component);
+    cecs_remove_component(ecs, e1, velocity_component);
+    cecs_remove_component(ecs, e1, position_component);
 
-    ECS_destroy_entity(ecs, e1);
+    cecs_destroy_entity(ecs, e1);
     
-    e0_vel = ECS_add_component(ecs, e0, velocity_component);
+    e0_vel = cecs_add_component(ecs, e0, velocity_component);
     *e0_vel = (Velocity){ 1,2,3 };
 
+    test_func(ecs, test_view_id);
     
 	return 0;
 }

--- a/include/cecs/archetype.h
+++ b/include/cecs/archetype.h
@@ -1,11 +1,11 @@
-#ifndef ARCHETYPE_H
-#define ARCHETYPE_H
+#ifndef CECS_ARCHETYPE_H
+#define CECS_ARCHETYPE_H
 
 #include <stdint.h>
 
-typedef uint16_t ArchetypeID;
+typedef uint16_t cecs_archetype_id_t;
 #define INVALID_ARCHETYPE UINT16_MAX
 
-typedef struct Archetype Archetype;
+typedef struct cecs_archetype_t cecs_archetype_t;
 
 #endif

--- a/include/cecs/component.h
+++ b/include/cecs/component.h
@@ -1,5 +1,5 @@
-#ifndef COMPONENT_H
-#define COMPONENT_H
+#ifndef CECS_COMPONENT_H
+#define CECS_COMPONENT_H
 
 #include <stdint.h>
 
@@ -11,17 +11,17 @@ TODO: Probably gotta rethink all of this at some point.
 // TODO: Write this out better anyways, don't need docs at top just above
          types etc.
 
-ComponentID
-- The ECS stores an array of components, hence, ComponentID is an index into that array.
+cecs_component_id_t
+- The cecs_t stores an array of components, hence, cecs_component_id_t is an index into that array.
 - TODO: Static sized array of components in ecs?
 
 ComponentBitset:
 - Represents flags for present components, this is for quicker comparisons.
 
-ComponentInfo: 
+cecs_component_info_t: 
 - Stores the sizeof(ComponentT) and it's ID (index in ecs components array).
 
-ComponentsSignature:
+cecs_components_signature_t:
 - Stores a bitset and array of component infos.
 
 */
@@ -30,41 +30,41 @@ ComponentsSignature:
 // TODO: Issue this only allows for 16 components. 
 //       In the future we could probably expand this to some array of bitsets.
 //       but that should be in the CHDS lib?
-typedef uint16_t ComponentsBitset; // TODO: Just signature?
-typedef uint8_t ComponentID; // TODO: Rename ids like ComponentId?
+typedef uint16_t cecs_components_bitset_t; // TODO: Just signature?
+typedef uint8_t cecs_component_id_t;
 
-#define COMPONENT_BITSET_SIZE 16 // TODO: Rename to MAX COMPONENTS?
-#define COMPONENTS_EMPTY_BITSET 0
+#define CECS_MAX_COMPONENTS 16
+#define CECS_EMPTY_COMPONENTS_BITSET 0
 
 // TODO: Should this be cast to something?
-#define COMPONENT_ID_TO_BITSET(id) (1 << id)
+#define CECS_COMPONENT_ID_TO_BITSET(id) (1 << id)
 
 
 
-
+// TODO: These are private right????? so we can/should/shouldnt? remove cecs prefix?
 
 // TODO: Document.......... why all this......
 
 // TODO: Should ID go in here?
 typedef struct
 {
-    ComponentID id; // TODO: Pretty sure we don't want this? Not sure.
+    cecs_component_id_t id; // TODO: Pretty sure we don't want this? Not sure.
     uint32_t size;
-} ComponentInfo;
+} cecs_component_info_t;
 
 // TODO: We don't need include/exclude here right?
-// TODO: Also is this really just an ArchetypeSignature?
+// TODO: Also is this really just an cecs_archetype_tSignature?
 typedef struct
 {
-    ComponentsBitset bitset;
+    cecs_components_bitset_t bitset;
 
     // TODO: chds_vec?
     // TODO: If we use a chds_vec then some sort of shrink to fit function
     //       could be nice, unless we can reserve before??
     int num_components;
-    ComponentInfo* infos;
+    cecs_component_info_t* infos;
 
-} ComponentsSignature;
+} cecs_components_signature_t;
 
 
 #endif

--- a/include/cecs/ecs.h
+++ b/include/cecs/ecs.h
@@ -19,7 +19,7 @@ typedef struct cecs_t cecs_t;
 // TODO: Comments for public usage.
 
 // cecs_t API
-cecs_t* cesc_create();
+cecs_t* cecs_create();
 // TODO: cecs_destroy(cecs_t* ecs);
 
 // Component API

--- a/include/cecs/ecs.h
+++ b/include/cecs/ecs.h
@@ -1,5 +1,5 @@
-#ifndef ECS_H
-#define ECS_H
+#ifndef CECS_H
+#define CECS_H
 
 // TODO: Forward declarations?
 #include "archetype.h"
@@ -7,7 +7,7 @@
 #include "entity.h"
 #include "view.h"
 
-typedef struct ECS ECS;
+typedef struct cecs_t cecs_t;
 
 // TODO: Terminology should be refactored to use table like names: 
 //       column, row, field etc.
@@ -18,28 +18,28 @@ typedef struct ECS ECS;
 
 // TODO: Comments for public usage.
 
-// ECS API
-ECS* ECS_create();
-// TODO: ECS_destroy(ECS* ecs);
+// cecs_t API
+cecs_t* cesc_create();
+// TODO: cecs_destroy(cecs_t* ecs);
 
 // Component API
-ComponentID ECS_register_component(ECS* ecs, uint32_t component_size);
+cecs_component_id_t cecs_regsiter_component(cecs_t* ecs, uint32_t component_size);
 
-void* ECS_add_component(ECS* ecs, EntityID eid, ComponentID cid);
-void ECS_remove_component(ECS* ecs, EntityID eid, ComponentID cid);
-void* ECS_get_component(ECS* ecs, EntityID eid, ComponentID cid);
+void* cecs_add_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
+void cecs_remove_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
+void* cecs_get_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
 
-// View API
-ViewID ECS_view(ECS* ecs, ComponentsBitset include, ComponentsBitset exclude);
-ViewIter ECS_view_iter(const ECS* ecs, ViewID vid);
+// cecs_view_t API
+cecs_view_id_t cecs_view(cecs_t* ecs, cecs_components_bitset_t include, cecs_components_bitset_t exclude);
+cecs_view_iter_t cecs_view_iter(const cecs_t* ecs, cecs_view_id_t vid);
 
-// TODO: Rename ViewIter_next? Then it would be nice to go in view.h but can't
+// TODO: Rename cecs_view_tIter_next? Then it would be nice to go in view.h but can't
 //       really right?
-int ECS_view_iter_next(ViewIter* it);
-void* ECS_get_column(ViewIter it, ComponentID cid);
+int cecs_view_iter_next(cecs_view_iter_t* it);
+void* cecs_get_column(cecs_view_iter_t it, cecs_component_id_t cid);
 
 // Entity API
-EntityID ECS_create_entity(ECS* ecs);
-void ECS_destroy_entity(ECS* ecs, EntityID id);
+cecs_entity_id_t cecs_create_entity(cecs_t* ecs);
+void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id);
 
 #endif

--- a/include/cecs/entity.h
+++ b/include/cecs/entity.h
@@ -1,9 +1,10 @@
-#ifndef ENTITY_H
-#define ENTITY_H
+#ifndef CECS_ENTITY_H
+#define CECS_ENTITY_H
 
 #include <stdint.h>
 
-typedef uint32_t EntityID;
+// TODO: it would be nice to shorten these names.
+typedef uint32_t cecs_entity_id_t;
 #define INVALID_ENTITY UINT32_MAX
 
 

--- a/include/cecs/view.h
+++ b/include/cecs/view.h
@@ -1,27 +1,27 @@
-#ifndef SYSTEM_H
-#define SYSTEM_H
+#ifndef CECS_SYSTEM_H
+#define CECS_SYSTEM_H
 
 #include "archetype.h"
 
 // TODO: COmment not implementation but how the user should use it!!!!
 
-typedef uint8_t ViewID;
+typedef uint8_t cecs_view_id_t;
 #define INVALID_VIEW UINT8_MAX
 
-typedef struct View View;
-typedef struct ECS ECS;
+typedef struct cecs_view_t cecs_view_t;
+typedef struct cecs_t cecs_t;
 
 typedef struct
 {
-    const ECS* ecs;
-    ViewID vid;
+    const cecs_t* ecs;
+    cecs_view_id_t vid;
 
-    ArchetypeID* aid;      // Current archetype.
+    cecs_archetype_id_t* aid;      // Current archetype.
     uint32_t rem;          // Remaining elements to iterate through.
 
     uint32_t num_entities; // Current number of entities in archetype.
 
-} ViewIter;
+} cecs_view_iter_t;
 
 
 

--- a/src/archetype.c
+++ b/src/archetype.c
@@ -4,12 +4,12 @@
 #include <string.h>
 
 // TODO: Not really necessary.
-void Archetype_init(Archetype* archetype)
+void cecs_archetype_init(cecs_archetype_t* archetype)
 {
-    memset(archetype, 0, sizeof(Archetype));
+    memset(archetype, 0, sizeof(cecs_archetype_t));
 }
 
-void Archetype_destroy(Archetype* archetype)
+void cecs_archetype_destroy(cecs_archetype_t* archetype)
 {
     for (int i = 0; i < archetype->signature.num_components; ++i)
     {
@@ -24,9 +24,9 @@ void Archetype_destroy(Archetype* archetype)
 // TODO: Currently a linear search, not ideal. Low number of components should be 
 //       fine but really want to improve this.
 // TODO: This sort of thing could be cached right? DEFINITELY. maybe this could relate to doing 'views'.
-void* Archetype_get_column(Archetype* archetype, ComponentID cid)
+void* cecs_archetype_get_column(cecs_archetype_t* archetype, cecs_component_id_t cid)
 {
-    const ComponentsSignature* signature = &archetype->signature;
+    const cecs_components_signature_t* signature = &archetype->signature;
     for (int i = 0; i < signature->num_components; ++i)
     {
         if (signature->infos[i].id == cid)

--- a/src/archetype_internal.h
+++ b/src/archetype_internal.h
@@ -1,5 +1,5 @@
-#ifndef ARCHETYPE_INTERNAL_H
-#define ARCHETYPE_INTERNAL_H
+#ifndef CECS_ARCHETYPE_INTERNAL_H
+#define CECS_ARCHETYPE_INTERNAL_H
 
 #include "archetype.h"
 
@@ -9,20 +9,20 @@
 #include <chds/vec.h>
 
 // Stores columns for entities matching a signature.
-typedef struct Archetype
+typedef struct cecs_archetype_t
 {
-    ComponentsSignature signature;
+    cecs_components_signature_t signature;
 
     // TODO: Some sort of map?
-    chds_vec(EntityID) index_to_entity;
+    chds_vec(cecs_entity_id_t) index_to_entity;
 
     void** columns;
 
-} Archetype;
+} cecs_archetype_t;
 
-// TODO: A bit misleading as the ECS actually properly initialises this.
-void Archetype_init(Archetype* archetype);
-void Archetype_destroy(Archetype* archetype);
-void* Archetype_get_column(Archetype* archetype, ComponentID cid);
+// TODO: A bit misleading as the cecs_t actually properly initialises this.
+void cecs_archetype_init(cecs_archetype_t* archetype);
+void cecs_archetype_destroy(cecs_archetype_t* archetype);
+void* cecs_archetype_get_column(cecs_archetype_t* archetype, cecs_component_id_t cid);
 
 #endif

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -25,7 +25,7 @@ static void cecs_archetype_remove_entity(cecs_t* ecs,
     int entity_index);
 
 // cecs_t API
-cecs_t* cesc_create()
+cecs_t* cecs_create()
 {
     cecs_t* ecs = calloc(1, sizeof(cecs_t));
     

--- a/src/ecs_internal.h
+++ b/src/ecs_internal.h
@@ -1,5 +1,5 @@
-#ifndef ECS_INTERNAL_H
-#define ECS_INTERNAL_H
+#ifndef CECS_INTERNAL_H
+#define CECS_INTERNAL_H
 
 #include "ecs.h"
 
@@ -7,29 +7,29 @@
 
 typedef struct
 {
-    ArchetypeID archetype_id;
+    cecs_archetype_id_t archetype_id;
     int column;
-} EntityIndex;
+} cecs_entity_index_t;
 
-typedef struct ECS
+typedef struct cecs_t
 {
     // Entities
     int num_used_entities;
 
-    EntityID* free_entities;
+    cecs_entity_id_t* free_entities;
     int free_entities_count;
     int free_entities_capacity;
 
-    ComponentsBitset* entity_components_bitsets;
+    cecs_components_bitset_t* entity_components_bitsets;
 
     // Stores the archetype that the entity belongs to and the position in that
     // archetype.
-    EntityIndex* entity_indices;
+    cecs_entity_index_t* entity_indices;
 
-    chds_vec(ComponentInfo) component_infos;
-    chds_vec(Archetype) archetypes;
-    chds_vec(View) views;
+    chds_vec(cecs_component_info_t) component_infos;
+    chds_vec(cecs_archetype_t) archetypes;
+    chds_vec(cecs_view_t) views;
 
-} ECS;
+} cecs_t;
 
 #endif

--- a/src/view.c
+++ b/src/view.c
@@ -1,7 +1,7 @@
 #include "view_internal.h"
 
-void View_destroy(View* view)
+void cecs_view_destroy(cecs_view_t* view)
 {
-    // TODO: Some ECS_destroy_view should probs call this.
+    // TODO: Some cecs_destroy_view should probs call this.
     chds_vec_destroy(view->archetype_ids);
 }

--- a/src/view_internal.h
+++ b/src/view_internal.h
@@ -1,5 +1,5 @@
-#ifndef VIEW_INTERNAL_H
-#define VIEW_INTERNAL_H
+#ifndef CECS_VIEW_INTERNAL_H
+#define CECS_VIEW_INTERNAL_H
 
 #include "view.h"
 
@@ -7,16 +7,16 @@
 
 #include <chds/vec.h>
 
-typedef struct View
+typedef struct cecs_view_t
 {
-    chds_vec(ArchetypeID) archetype_ids;
+    chds_vec(cecs_archetype_id_t) archetype_ids;
 
     // TODO: Document
-    ComponentsBitset include;
-    ComponentsBitset exclude;
+    cecs_components_bitset_t include;
+    cecs_components_bitset_t exclude;
 
-} View;
+} cecs_view_t;
 
-void View_destroy(View* view);
+void cecs_view_destroy(cecs_view_t* view);
 
 #endif

--- a/tests/test_entity.h
+++ b/tests/test_entity.h
@@ -7,7 +7,7 @@
 
 inline void test_create()
 {
-    cecs_t* ecs = cesc_create();
+    cecs_t* ecs = cecs_create();
     cecs_entity_id_t e = cecs_create_entity(ecs);
 
     assert(e != INVALID_ENTITY);

--- a/tests/test_entity.h
+++ b/tests/test_entity.h
@@ -7,8 +7,8 @@
 
 inline void test_create()
 {
-    ECS* ecs = ECS_create();
-    EntityID e = ECS_create_entity(ecs);
+    cecs_t* ecs = cesc_create();
+    cecs_entity_id_t e = cecs_create_entity(ecs);
 
     assert(e != INVALID_ENTITY);
 }


### PR DESCRIPTION
For a while I've wanted to swap to snake_case for everything as I didn't like when a function would be like A_create_b but A & B are types, I did not like the mix of capitals and none capitals. This is in response to the update for CHDS.