### PR TITLE
remove _t suffix and fix chds naming to new convention

### DIFF
--- a/examples/main.c
+++ b/examples/main.c
@@ -8,9 +8,9 @@
 // TODO: Get a better example working, how can we define components.. - this cannot be done at compile time i believe.
 
 // TODO: How do we fix this.
-cecs_component_id_t position_component;
-cecs_component_id_t velocity_component;
-cecs_component_id_t health_component;
+cecs_component_id position_component;
+cecs_component_id velocity_component;
+cecs_component_id health_component;
 
 typedef struct
 {
@@ -28,9 +28,9 @@ typedef struct
     int max;
 } Health;
 
-static void test_func(cecs_t* ecs, cecs_view_id_t view_id)
+static void test_func(cecs* ecs, cecs_view_id view_id)
 {
-    cecs_view_iter_t it = cecs_view_iter(ecs, view_id);
+    cecs_view_iter it = cecs_view_iter_create(ecs, view_id);
     while (cecs_view_iter_next(&it))
     {
         Position* positions = cecs_get_column(it, position_component);
@@ -51,21 +51,21 @@ static void test_func(cecs_t* ecs, cecs_view_id_t view_id)
 
 int main()
 {
-    cecs_t* ecs = cecs_create();
+    cecs* ecs = cecs_create();
     
     position_component = cecs_register_component(ecs, sizeof(Position));
     velocity_component = cecs_register_component(ecs, sizeof(Velocity));
     health_component = cecs_register_component(ecs, sizeof(Health));
 
     // Register a test view that uses position, velocity but excludes health.
-    cecs_view_id_t test_view_id = cecs_view(ecs,
+    cecs_view_id test_view_id = cecs_create_view(ecs,
         CECS_COMPONENT_ID_TO_BITSET(position_component) | CECS_COMPONENT_ID_TO_BITSET(velocity_component),
         CECS_COMPONENT_ID_TO_BITSET(health_component)
     );
 
     // TODO: Document how component pointers are only valid until the 
     //       next component is added!! or like how it actually works....
-    cecs_entity_id_t e0 = cecs_create_entity(ecs);
+    cecs_entity_id e0 = cecs_create_entity(ecs);
 
     Position* e0_pos = cecs_add_component(ecs, e0, position_component);
     e0_pos->x = 1;
@@ -79,7 +79,9 @@ int main()
 
     cecs_remove_component(ecs, e0, velocity_component);
     
-    cecs_entity_id_t e1 = cecs_create_entity(ecs);
+    // TODO: Can definitely rename to -> cecs_entity instead,
+    //       the id part is unnecessary.
+    cecs_entity_id e1 = cecs_create_entity(ecs);
     cecs_add_component(ecs, e1, velocity_component);
     cecs_add_component(ecs, e1, position_component);
     cecs_add_component(ecs, e1, health_component);

--- a/include/cecs/archetype.h
+++ b/include/cecs/archetype.h
@@ -3,9 +3,9 @@
 
 #include <stdint.h>
 
-typedef uint16_t cecs_archetype_id_t;
+typedef uint16_t cecs_archetype_id;
 #define INVALID_ARCHETYPE UINT16_MAX
 
-typedef struct cecs_archetype_t cecs_archetype_t;
+typedef struct cecs_archetype cecs_archetype;
 
 #endif

--- a/include/cecs/component.h
+++ b/include/cecs/component.h
@@ -11,17 +11,17 @@ TODO: Probably gotta rethink all of this at some point.
 // TODO: Write this out better anyways, don't need docs at top just above
          types etc.
 
-cecs_component_id_t
-- The cecs_t stores an array of components, hence, cecs_component_id_t is an index into that array.
+cecs_component_id
+- The cecs stores an array of components, hence, cecs_component_id is an index into that array.
 - TODO: Static sized array of components in ecs?
 
 ComponentBitset:
 - Represents flags for present components, this is for quicker comparisons.
 
-cecs_component_info_t: 
+cecs_component_info: 
 - Stores the sizeof(ComponentT) and it's ID (index in ecs components array).
 
-cecs_components_signature_t:
+cecs_components_signature:
 - Stores a bitset and array of component infos.
 
 */
@@ -30,12 +30,12 @@ cecs_components_signature_t:
 // TODO: Issue this only allows for 16 components. 
 //       In the future we could probably expand this to some array of bitsets.
 //       but that should be in the CHDS lib?
-typedef uint16_t cecs_components_bitset_t; // TODO: Just signature?
-typedef uint8_t cecs_component_id_t;
+typedef uint16_t cecs_components_bitset; // TODO: Just signature?
+typedef uint8_t cecs_component_id;
 
 #define CECS_MAX_COMPONENTS 16
 #define CECS_EMPTY_COMPONENTS_BITSET 0
 
-#define CECS_COMPONENT_ID_TO_BITSET(id) (cecs_components_bitset_t)(1 << id)
+#define CECS_COMPONENT_ID_TO_BITSET(id) (cecs_components_bitset)(1 << id)
 
 #endif

--- a/include/cecs/ecs.h
+++ b/include/cecs/ecs.h
@@ -7,7 +7,7 @@
 #include "entity.h"
 #include "view.h"
 
-typedef struct cecs_t cecs_t;
+typedef struct cecs cecs;
 
 // TODO: Terminology should be refactored to use table like names: 
 //       column, row, field etc.
@@ -18,28 +18,28 @@ typedef struct cecs_t cecs_t;
 
 // TODO: Comments for public usage.
 
-// cecs_t API
-cecs_t* cecs_create();
-// TODO: cecs_destroy(cecs_t* ecs);
+// cecs API
+cecs* cecs_create();
+// TODO: cecs_destroy(cecs* ecs);
 
 // Component API
-cecs_component_id_t cecs_register_component(cecs_t* ecs, uint32_t component_size);
+cecs_component_id cecs_register_component(cecs* ecs, uint32_t component_size);
 
-void* cecs_add_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
-void cecs_remove_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
-void* cecs_get_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid);
+void* cecs_add_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid);
+void cecs_remove_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid);
+void* cecs_get_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid);
 
-// cecs_view_t API
-cecs_view_id_t cecs_view(cecs_t* ecs, cecs_components_bitset_t include, cecs_components_bitset_t exclude);
-cecs_view_iter_t cecs_view_iter(const cecs_t* ecs, cecs_view_id_t vid);
+// cecs_view API
+cecs_view_id cecs_create_view(cecs* ecs, cecs_components_bitset include, cecs_components_bitset exclude);
+cecs_view_iter cecs_view_iter_create(const cecs* ecs, cecs_view_id vid);
 
 // TODO: Rename cecs_view_tIter_next? Then it would be nice to go in view.h but can't
 //       really right?
-int cecs_view_iter_next(cecs_view_iter_t* it);
-void* cecs_get_column(cecs_view_iter_t it, cecs_component_id_t cid);
+int cecs_view_iter_next(cecs_view_iter* it);
+void* cecs_get_column(cecs_view_iter it, cecs_component_id cid);
 
 // Entity API
-cecs_entity_id_t cecs_create_entity(cecs_t* ecs);
-void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id);
+cecs_entity_id cecs_create_entity(cecs* ecs);
+void cecs_destroy_entity(cecs* ecs, cecs_entity_id id);
 
 #endif

--- a/include/cecs/entity.h
+++ b/include/cecs/entity.h
@@ -4,7 +4,9 @@
 #include <stdint.h>
 
 // TODO: it would be nice to shorten these names.
-typedef uint32_t cecs_entity_id_t;
+// TODO: Can definitely rename to -> cecs_entity instead,
+//       the id part is unnecessary.
+typedef uint32_t cecs_entity_id;
 #define INVALID_ENTITY UINT32_MAX
 
 

--- a/include/cecs/view.h
+++ b/include/cecs/view.h
@@ -5,23 +5,23 @@
 
 // TODO: COmment not implementation but how the user should use it!!!!
 
-typedef uint8_t cecs_view_id_t;
+typedef uint8_t cecs_view_id;
 #define INVALID_VIEW UINT8_MAX
 
-typedef struct cecs_view_t cecs_view_t;
-typedef struct cecs_t cecs_t;
+typedef struct cecs_view cecs_view;
+typedef struct cecs cecs;
 
 typedef struct
 {
-    const cecs_t* ecs;
-    cecs_view_id_t vid;
+    const cecs* ecs;
+    cecs_view_id vid;
 
-    cecs_archetype_id_t* aid;      // Current archetype.
+    cecs_archetype_id* aid;      // Current archetype.
     uint32_t rem;          // Remaining elements to iterate through.
 
     uint32_t num_entities; // Current number of entities in archetype.
 
-} cecs_view_iter_t;
+} cecs_view_iter;
 
 
 

--- a/src/archetype.c
+++ b/src/archetype.c
@@ -4,12 +4,12 @@
 #include <string.h>
 
 // TODO: Not really necessary.
-void cecs_archetype_init(cecs_archetype_t* archetype)
+void cecs_archetype_init(cecs_archetype* archetype)
 {
-    memset(archetype, 0, sizeof(cecs_archetype_t));
+    memset(archetype, 0, sizeof(cecs_archetype));
 }
 
-void cecs_archetype_destroy(cecs_archetype_t* archetype)
+void cecs_archetype_destroy(cecs_archetype* archetype)
 {
     for (int i = 0; i < archetype->signature.num_components; ++i)
     {
@@ -24,9 +24,9 @@ void cecs_archetype_destroy(cecs_archetype_t* archetype)
 // TODO: Currently a linear search, not ideal. Low number of components should be 
 //       fine but really want to improve this.
 // TODO: This sort of thing could be cached right? DEFINITELY. maybe this could relate to doing 'views'.
-void* cecs_archetype_get_column(cecs_archetype_t* archetype, cecs_component_id_t cid)
+void* cecs_archetype_get_column(cecs_archetype* archetype, cecs_component_id cid)
 {
-    const cecs_components_signature_t* signature = &archetype->signature;
+    const cecs_components_signature* signature = &archetype->signature;
     for (int i = 0; i < signature->num_components; ++i)
     {
         if (signature->infos[i].id == cid)

--- a/src/archetype_internal.h
+++ b/src/archetype_internal.h
@@ -9,20 +9,20 @@
 #include <chds/vec.h>
 
 // Stores columns for entities matching a signature.
-typedef struct cecs_archetype_t
+typedef struct cecs_archetype
 {
-    cecs_components_signature_t signature;
+    cecs_components_signature signature;
 
     // TODO: Some sort of map?
-    chds_vec(cecs_entity_id_t) index_to_entity;
+    CHDS_VEC(cecs_entity_id) index_to_entity;
 
     void** columns;
 
-} cecs_archetype_t;
+} cecs_archetype;
 
-// TODO: A bit misleading as the cecs_t actually properly initialises this.
-void cecs_archetype_init(cecs_archetype_t* archetype);
-void cecs_archetype_destroy(cecs_archetype_t* archetype);
-void* cecs_archetype_get_column(cecs_archetype_t* archetype, cecs_component_id_t cid);
+// TODO: A bit misleading as the cecs actually properly initialises this.
+void cecs_archetype_init(cecs_archetype* archetype);
+void cecs_archetype_destroy(cecs_archetype* archetype);
+void* cecs_archetype_get_column(cecs_archetype* archetype, cecs_component_id cid);
 
 #endif

--- a/src/component_internal.h
+++ b/src/component_internal.h
@@ -10,22 +10,22 @@
 // TODO: Should ID go in here?
 typedef struct
 {
-    cecs_component_id_t id; // TODO: Pretty sure we don't want this? Not sure.
+    cecs_component_id id; // TODO: Pretty sure we don't want this? Not sure.
     uint32_t size;
-} cecs_component_info_t;
+} cecs_component_info;
 
 // TODO: We don't need include/exclude here right?
 // TODO: Also is this really just an cecs_archetype_tSignature?
 typedef struct
 {
-    cecs_components_bitset_t bitset;
+    cecs_components_bitset bitset;
 
-    // TODO: chds_vec?
-    // TODO: If we use a chds_vec then some sort of shrink to fit function
+    // TODO: CHDS_VEC?
+    // TODO: If we use a CHDS_VEC then some sort of shrink to fit function
     //       could be nice, unless we can reserve before??
     int num_components;
-    cecs_component_info_t* infos;
+    cecs_component_info* infos;
 
-} cecs_components_signature_t;
+} cecs_components_signature;
 
 #endif

--- a/src/ecs.c
+++ b/src/ecs.c
@@ -8,33 +8,33 @@
 #include <stdio.h>
 #include <assert.h>
 
-static cecs_archetype_id_t cecs_create_archetype(cecs_t* ecs, 
-    cecs_components_bitset_t archetype_bitset);
+static cecs_archetype_id cecs_create_archetype(cecs* ecs, 
+    cecs_components_bitset archetype_bitset);
 
-static void cecs_move_archetype(cecs_t* ecs, 
-    cecs_entity_id_t id, 
-    cecs_archetype_id_t old_archetype_id,
-    cecs_archetype_id_t new_archetype_id);
+static void cecs_move_archetype(cecs* ecs, 
+    cecs_entity_id id, 
+    cecs_archetype_id old_archetype_id,
+    cecs_archetype_id new_archetype_id);
 
-static void cecs_archetype_add_entity(const cecs_t* ecs, 
-    cecs_archetype_t* archetype,
-    cecs_entity_id_t eid);
+static void cecs_archetype_add_entity(const cecs* ecs, 
+    cecs_archetype* archetype,
+    cecs_entity_id eid);
 
-static void cecs_archetype_remove_entity(cecs_t* ecs, 
-    cecs_archetype_t* archetype,
+static void cecs_archetype_remove_entity(cecs* ecs, 
+    cecs_archetype* archetype,
     int entity_index);
 
-// cecs_t API
-cecs_t* cecs_create()
+// cecs API
+cecs* cecs_create()
 {
-    cecs_t* ecs = calloc(1, sizeof(cecs_t));
+    cecs* ecs = calloc(1, sizeof(cecs));
     
     // Ensure an empty archetype exists to store entities without components.
     // NOTE: This logic may be refactored in the future so that there is no 
     //       need for this empty archetype! The issue being removing an entity's
     //       last component. Also, keeping this simplifies other logic as it means
     //       an entity always has an archetype!
-    cecs_archetype_id_t empty_archetype = cecs_create_archetype(ecs, 0);
+    cecs_archetype_id empty_archetype = cecs_create_archetype(ecs, 0);
 
     // Ensure the archetype is valid and matches the hardcoded index.
     if (empty_archetype == INVALID_ARCHETYPE || empty_archetype != EMPTY_ARCHETYPE_ID)
@@ -46,20 +46,20 @@ cecs_t* cecs_create()
     return ecs;
 }
 
-cecs_component_id_t cecs_register_component(cecs_t* ecs, uint32_t component_size)
+cecs_component_id cecs_register_component(cecs* ecs, uint32_t component_size)
 {
     // Store the size of the component for resizing archetype arrays.
-    cecs_component_info_t ci = {
+    cecs_component_info ci = {
         .size = component_size,
-        .id = (cecs_component_id_t)chds_vec_size(ecs->component_infos)
+        .id = (cecs_component_id)CHDS_VEC_SIZE(ecs->component_infos)
     };
-    chds_vec_push_back(ecs->component_infos, ci);
+    CHDS_VEC_PUSH_BACK(ecs->component_infos, ci);
 
     return ci.id;
 }
 
 // TODO: Some function for passing in component ids separately to create bitsets.
-cecs_view_id_t cecs_view(cecs_t* ecs, cecs_components_bitset_t include, cecs_components_bitset_t exclude)
+cecs_view_id cecs_create_view(cecs* ecs, cecs_components_bitset include, cecs_components_bitset exclude)
 {
     // TODO: Should write tests for this sort of thing!
     // Include and exclude cannot have matching bits.
@@ -68,13 +68,13 @@ cecs_view_id_t cecs_view(cecs_t* ecs, cecs_components_bitset_t include, cecs_com
         return INVALID_VIEW;
     }
 
-    cecs_view_id_t num_views = (cecs_view_id_t)chds_vec_size(ecs->views);
+    cecs_view_id num_views = (cecs_view_id)CHDS_VEC_SIZE(ecs->views);
 
     // Look for existing view.
     // TODO: Map would be nicer.
     for (int i = 0; i < num_views; ++i)
     {
-        cecs_view_t* v = &ecs->views[i];
+        cecs_view* v = &ecs->views[i];
         if (v->include == include &&
             v->exclude == exclude)
         {
@@ -82,49 +82,49 @@ cecs_view_id_t cecs_view(cecs_t* ecs, cecs_components_bitset_t include, cecs_com
         }
     }
 
-    chds_vec_push_back(ecs->views, ((cecs_view_t) { 
+    CHDS_VEC_PUSH_BACK(ecs->views, ((cecs_view) { 
         .include = include, 
         .exclude = exclude 
     }));
 
-    cecs_view_t* v = &ecs->views[num_views];
+    cecs_view* v = &ecs->views[num_views];
 
     // Load matching archetypes into ecs.
-    size_t num_archetypes = chds_vec_size(ecs->archetypes);
+    size_t num_archetypes = CHDS_VEC_SIZE(ecs->archetypes);
     for (int aid = 0; aid < num_archetypes; ++aid)
     {
-        const cecs_components_bitset_t bits = ecs->archetypes[aid].signature.bitset;
+        const cecs_components_bitset bits = ecs->archetypes[aid].signature.bitset;
         
         // TODO: Some helper function for this?
-        // cecs_archetype_t bitset must have at least the include bits but
+        // cecs_archetype bitset must have at least the include bits but
         // none of the exclude ones.
         if ((bits & include) == include &&
             (bits & exclude) == 0)
         {
-            chds_vec_push_back(v->archetype_ids, aid);
+            CHDS_VEC_PUSH_BACK(v->archetype_ids, aid);
         }
     }
 
     return num_views;
 }
 
-cecs_view_iter_t cecs_view_iter(const cecs_t* ecs, const cecs_view_id_t vid)
+cecs_view_iter cecs_view_iter_create(const cecs* ecs, const cecs_view_id vid)
 {
-    cecs_view_t* view = &ecs->views[vid];
+    cecs_view* view = &ecs->views[vid];
 
-    uint32_t num_archetypes = (uint32_t)chds_vec_size(view->archetype_ids);
+    uint32_t num_archetypes = (uint32_t)CHDS_VEC_SIZE(view->archetype_ids);
     uint32_t num_entities = 0;
 
     // Avoid ptr arithmetic on nullptr.
-    cecs_archetype_id_t* start = 0;
+    cecs_archetype_id* start = 0;
 
     if (num_archetypes > 0)
     {
         start = view->archetype_ids - 1; // Offset by 1 because of initial increment.
-        num_entities = (uint32_t)chds_vec_size(ecs->archetypes[view->archetype_ids[0]].index_to_entity);
+        num_entities = (uint32_t)CHDS_VEC_SIZE(ecs->archetypes[view->archetype_ids[0]].index_to_entity);
     }
 
-    cecs_view_iter_t it = {
+    cecs_view_iter it = {
         .ecs = ecs,
         .vid = vid,
         .aid = start,
@@ -134,7 +134,7 @@ cecs_view_iter_t cecs_view_iter(const cecs_t* ecs, const cecs_view_id_t vid)
     return it;
 }
 
-int cecs_view_iter_next(cecs_view_iter_t* it)
+int cecs_view_iter_next(cecs_view_iter* it)
 {
     if (it->rem == 0) return 0;
     --it->rem;
@@ -142,19 +142,19 @@ int cecs_view_iter_next(cecs_view_iter_t* it)
     // Move to next archetype.
     ++it->aid;
 
-    it->num_entities = (uint32_t)chds_vec_size(it->ecs->archetypes[*it->aid].index_to_entity);
+    it->num_entities = (uint32_t)CHDS_VEC_SIZE(it->ecs->archetypes[*it->aid].index_to_entity);
 
     return 1;
 }
 
-void* cecs_get_column(cecs_view_iter_t it, cecs_component_id_t cid)
+void* cecs_get_column(cecs_view_iter it, cecs_component_id cid)
 {
     return cecs_archetype_get_column(&it.ecs->archetypes[*it.aid], cid);
 }
 
-cecs_entity_id_t cecs_create_entity(cecs_t* ecs)
+cecs_entity_id cecs_create_entity(cecs* ecs)
 {
-    cecs_entity_id_t entity;
+    cecs_entity_id entity;
 
     ++ecs->num_used_entities;
 
@@ -172,8 +172,8 @@ cecs_entity_id_t cecs_create_entity(cecs_t* ecs)
 
         // TODO: Grow by some factor to save allocations?
         // TODO: Really need to do this!
-        cecs_components_bitset_t* temp_bitsets = realloc(ecs->entity_components_bitsets,
-            total_created_entities * sizeof(cecs_components_bitset_t));
+        cecs_components_bitset* temp_bitsets = realloc(ecs->entity_components_bitsets,
+            total_created_entities * sizeof(cecs_components_bitset));
 
         if (!temp_bitsets)
         {
@@ -182,8 +182,8 @@ cecs_entity_id_t cecs_create_entity(cecs_t* ecs)
         }
         ecs->entity_components_bitsets = temp_bitsets;
 
-        cecs_entity_index_t* temp_indices = realloc(ecs->entity_indices, 
-            total_created_entities * sizeof(cecs_entity_index_t));
+        cecs_entity_index* temp_indices = realloc(ecs->entity_indices, 
+            total_created_entities * sizeof(cecs_entity_index));
         if (!temp_indices)
         {
             printf("Failed to alloc for ecs->entity_indices.\n");
@@ -206,14 +206,14 @@ cecs_entity_id_t cecs_create_entity(cecs_t* ecs)
 }
 
 // TODO: Rename destroy?
-void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id)
+void cecs_destroy_entity(cecs* ecs, cecs_entity_id id)
 {
     --ecs->num_used_entities;
 
     // Entities don't need to be packed as we will never be iterating over the entities loop.
 
     // Clear entity signature.
-    const cecs_components_bitset_t old_bitset = ecs->entity_components_bitsets[id];
+    const cecs_components_bitset old_bitset = ecs->entity_components_bitsets[id];
     ecs->entity_components_bitsets[id] = CECS_EMPTY_COMPONENTS_BITSET;
 
     // Grow capacity if needed.
@@ -222,7 +222,7 @@ void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id)
         // TODO: Grow by factor?
         ++ecs->free_entities_capacity;
 
-        cecs_entity_id_t* temp_free_entities = realloc(ecs->free_entities, ecs->free_entities_capacity * sizeof(cecs_entity_id_t));
+        cecs_entity_id* temp_free_entities = realloc(ecs->free_entities, ecs->free_entities_capacity * sizeof(cecs_entity_id));
         if (!temp_free_entities)
         {
             printf("failed to grow ecs->free_entities\n");
@@ -238,10 +238,10 @@ void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id)
     // Remove entity from it's archetype, which should remove it's components,
     // note, sadly we have to search for the archetype. Could use a map from
     // entity id to archetype id (index). TODO: consider.
-    size_t num_archetypes = chds_vec_size(ecs->archetypes);
+    size_t num_archetypes = CHDS_VEC_SIZE(ecs->archetypes);
     for (int i = 0; i < num_archetypes; ++i)
     {
-        cecs_archetype_t* archetype = &ecs->archetypes[i];
+        cecs_archetype* archetype = &ecs->archetypes[i];
         if (archetype->signature.bitset == old_bitset)
         {
             cecs_archetype_remove_entity(ecs, archetype, ecs->entity_indices[id].column);
@@ -250,10 +250,10 @@ void cecs_destroy_entity(cecs_t* ecs, cecs_entity_id_t id)
     }
 }
 
-void* cecs_add_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid)
+void* cecs_add_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid)
 {
-    const cecs_components_bitset_t old_components_bitset = ecs->entity_components_bitsets[eid];
-    const cecs_component_id_t component_bitset = CECS_COMPONENT_ID_TO_BITSET(cid);
+    const cecs_components_bitset old_components_bitset = ecs->entity_components_bitsets[eid];
+    const cecs_component_id component_bitset = CECS_COMPONENT_ID_TO_BITSET(cid);
 
     // Entity already has component, return that component instead.
     if (old_components_bitset & component_bitset)
@@ -271,10 +271,10 @@ void* cecs_add_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t 
     // TODO: Is there a nicer way to do this using some sort of mapping, brute 
     //       force search not ideal but shouldn't be a big issue for now.
 
-    // Must use cecs_archetype_id_t as if we create a new archetype we will invalidate the pointers.
-    cecs_archetype_id_t new_archetype_id = INVALID_ARCHETYPE;
-    cecs_archetype_id_t old_archetype_id = INVALID_ARCHETYPE;
-    const size_t num_archetypes = chds_vec_size(ecs->archetypes);
+    // Must use cecs_archetype_id as if we create a new archetype we will invalidate the pointers.
+    cecs_archetype_id new_archetype_id = INVALID_ARCHETYPE;
+    cecs_archetype_id old_archetype_id = INVALID_ARCHETYPE;
+    const size_t num_archetypes = CHDS_VEC_SIZE(ecs->archetypes);
     for (int i = 0; i < num_archetypes; ++i)
     {
         if (ecs->archetypes[i].signature.bitset == old_components_bitset)
@@ -299,10 +299,10 @@ void* cecs_add_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t 
     return cecs_get_component(ecs, eid, cid);
 }
 
-void cecs_remove_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid)
+void cecs_remove_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid)
 {
-    const cecs_components_bitset_t old_components_bitset = ecs->entity_components_bitsets[eid];
-    const cecs_component_id_t component_bitset = CECS_COMPONENT_ID_TO_BITSET(cid);
+    const cecs_components_bitset old_components_bitset = ecs->entity_components_bitsets[eid];
+    const cecs_component_id component_bitset = CECS_COMPONENT_ID_TO_BITSET(cid);
 
     // Entity doesn't have the component.
     if (!(old_components_bitset & component_bitset))
@@ -320,10 +320,10 @@ void cecs_remove_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_
     // TODO: Is there a nicer way to do this using some sort of mapping, brute 
     //       force search not ideal but shouldn't be a big issue for now.
 
-    // Must use cecs_archetype_id_t as if we create a new archetype we will invalidate the pointers.
-    cecs_archetype_id_t new_archetype_id = INVALID_ARCHETYPE;
-    cecs_archetype_id_t old_archetype_id = INVALID_ARCHETYPE;
-    const size_t num_archetypes = chds_vec_size(ecs->archetypes);
+    // Must use cecs_archetype_id as if we create a new archetype we will invalidate the pointers.
+    cecs_archetype_id new_archetype_id = INVALID_ARCHETYPE;
+    cecs_archetype_id old_archetype_id = INVALID_ARCHETYPE;
+    const size_t num_archetypes = CHDS_VEC_SIZE(ecs->archetypes);
     for (int i = 0; i < num_archetypes; ++i)
     {
         if (ecs->archetypes[i].signature.bitset == old_components_bitset)
@@ -347,10 +347,10 @@ void cecs_remove_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_
     cecs_move_archetype(ecs, eid, old_archetype_id, new_archetype_id);
 }
 
-void* cecs_get_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t cid)
+void* cecs_get_component(cecs* ecs, cecs_entity_id eid, cecs_component_id cid)
 {
-    cecs_entity_index_t ei = ecs->entity_indices[eid];
-    cecs_archetype_t* archetype = &ecs->archetypes[ei.archetype_id];
+    cecs_entity_index ei = ecs->entity_indices[eid];
+    cecs_archetype* archetype = &ecs->archetypes[ei.archetype_id];
     
     int size = ecs->component_infos[cid].size;
 
@@ -369,20 +369,20 @@ void* cecs_get_component(cecs_t* ecs, cecs_entity_id_t eid, cecs_component_id_t 
 // Internal helper functions
 // TODO: Should these private functions be moved elsewhere? They're not
 //       intended to be part of the public api.
-static cecs_archetype_id_t cecs_create_archetype(cecs_t* ecs, 
-    cecs_components_bitset_t archetype_bitset)
+static cecs_archetype_id cecs_create_archetype(cecs* ecs, 
+    cecs_components_bitset archetype_bitset)
 {
     // Currently we're allowing for an empty archetype to keep the logic simple,
     // so that every entity lives in an archetype. May change in the future.
-    cecs_archetype_id_t archetype_id = (cecs_archetype_id_t)chds_vec_size(ecs->archetypes);
-    cecs_archetype_t new_archetype = {
+    cecs_archetype_id archetype_id = (cecs_archetype_id)CHDS_VEC_SIZE(ecs->archetypes);
+    cecs_archetype new_archetype = {
         .signature = {
             .bitset = archetype_bitset
         }
     };
 
-    chds_vec_push_back(ecs->archetypes, new_archetype);
-    cecs_archetype_t* archetype = &ecs->archetypes[archetype_id];
+    CHDS_VEC_PUSH_BACK(ecs->archetypes, new_archetype);
+    cecs_archetype* archetype = &ecs->archetypes[archetype_id];
 
     // TODO: Remove cecs_archetype_init?
     //cecs_archetype_init(archetype);
@@ -390,14 +390,14 @@ static cecs_archetype_id_t cecs_create_archetype(cecs_t* ecs,
     // Create archetype signature from bitset.
     for (int i = 0; i < CECS_MAX_COMPONENTS; ++i)
     {
-        cecs_components_bitset_t bitset = CECS_COMPONENT_ID_TO_BITSET(i);
+        cecs_components_bitset bitset = CECS_COMPONENT_ID_TO_BITSET(i);
 
         // Check if the archetype should have this component.
         if (bitset & archetype_bitset)
         {
-            cecs_component_info_t* temp = realloc(archetype->signature.infos,
+            cecs_component_info* temp = realloc(archetype->signature.infos,
                 (size_t)(archetype->signature.num_components + 1) * 
-                sizeof(cecs_component_info_t));
+                sizeof(cecs_component_info));
 
             if (!temp)
             {
@@ -437,34 +437,34 @@ static cecs_archetype_id_t cecs_create_archetype(cecs_t* ecs,
     }
 
     // Add the archetype to all views that fit it's signature.
-    const size_t num_views = chds_vec_size(ecs->views);
+    const size_t num_views = CHDS_VEC_SIZE(ecs->views);
     for (int i = 0; i < num_views; ++i)
     {
-        cecs_view_t* view = &ecs->views[i];
+        cecs_view* view = &ecs->views[i];
 
         if ((archetype_bitset & view->include) == view->include &&
             (archetype_bitset & view->exclude) == 0)
         {
-            chds_vec_push_back(view->archetype_ids, archetype_id);
+            CHDS_VEC_PUSH_BACK(view->archetype_ids, archetype_id);
         }
     }
 
     return archetype_id;
 }
 
-static void cecs_move_archetype(cecs_t* ecs, cecs_entity_id_t id, cecs_archetype_id_t old_archetype_id,
-    cecs_archetype_id_t new_archetype_id)
+static void cecs_move_archetype(cecs* ecs, cecs_entity_id id, cecs_archetype_id old_archetype_id,
+    cecs_archetype_id new_archetype_id)
 {
     // Add the entity to the new archetype.
-    cecs_archetype_t* new_archetype = &ecs->archetypes[new_archetype_id];
+    cecs_archetype* new_archetype = &ecs->archetypes[new_archetype_id];
     cecs_archetype_add_entity(ecs, new_archetype, id);
     // TODO: Confirm this succeeeded?
 
     // Copy where the entity used to live.
-    const cecs_entity_index_t old_entity_index = ecs->entity_indices[id];
+    const cecs_entity_index old_entity_index = ecs->entity_indices[id];
        
     // Get the index of the last entity in the archetype.
-    int column = (int)chds_vec_size(new_archetype->index_to_entity) - 1;
+    int column = (int)CHDS_VEC_SIZE(new_archetype->index_to_entity) - 1;
 
     // Update information on where the entity is.
     ecs->entity_indices[id].archetype_id = new_archetype_id;
@@ -473,7 +473,7 @@ static void cecs_move_archetype(cecs_t* ecs, cecs_entity_id_t id, cecs_archetype
     // Check for an old archetype.
     // NOTE: There should always be an old archetype except if the entity has just been
     //       created and is being moved to the empty archetype!
-    cecs_archetype_t* old_archetype = 0;
+    cecs_archetype* old_archetype = 0;
     if (old_archetype_id != INVALID_ARCHETYPE)
     {
         old_archetype = &ecs->archetypes[old_archetype_id];
@@ -495,12 +495,12 @@ static void cecs_move_archetype(cecs_t* ecs, cecs_entity_id_t id, cecs_archetype
     // For each component in the new archetype, search the old archetype for a matching one.
     for (int i = 0; i < new_archetype->signature.num_components; ++i)
     {
-        cecs_component_id_t cid_new = new_archetype->signature.infos[i].id;
+        cecs_component_id cid_new = new_archetype->signature.infos[i].id;
 
         int old_component_list_i = -1;
         for (int j = 0; j < old_archetype->signature.num_components; ++j)
         {
-            cecs_component_id_t cid_old = old_archetype->signature.infos[j].id;
+            cecs_component_id cid_old = old_archetype->signature.infos[j].id;
             if (cid_new == cid_old) 
             {
                 old_component_list_i = j;
@@ -511,7 +511,7 @@ static void cecs_move_archetype(cecs_t* ecs, cecs_entity_id_t id, cecs_archetype
         // Not found, so nothing to copy from old to new.
         if (old_component_list_i == -1) continue;
 
-        const cecs_component_info_t info = ecs->component_infos[cid_new];
+        const cecs_component_info info = ecs->component_infos[cid_new];
 
         // Convert void* to byte array so we can do pointer arithmetic.
 
@@ -535,8 +535,8 @@ static void cecs_move_archetype(cecs_t* ecs, cecs_entity_id_t id, cecs_archetype
     cecs_archetype_remove_entity(ecs, old_archetype, old_entity_index.column);
 }
 
-static void cecs_archetype_add_entity(const cecs_t* ecs, cecs_archetype_t* archetype, 
-    cecs_entity_id_t eid)
+static void cecs_archetype_add_entity(const cecs* ecs, cecs_archetype* archetype, 
+    cecs_entity_id eid)
 {
     // TODO: Move to archetype.c
 
@@ -546,9 +546,9 @@ static void cecs_archetype_add_entity(const cecs_t* ecs, cecs_archetype_t* arche
     //       now there is 
 
     // TODO: Hack, not sure how else to do this.
-    size_t old_capacity = chds_vec_capacity(archetype->index_to_entity);
-    chds_vec_push_back(archetype->index_to_entity, eid);
-    size_t new_capacity = chds_vec_capacity(archetype->index_to_entity);
+    size_t old_capacity = CHDS_VEC_CAPACITY(archetype->index_to_entity);
+    CHDS_VEC_PUSH_BACK(archetype->index_to_entity, eid);
+    size_t new_capacity = CHDS_VEC_CAPACITY(archetype->index_to_entity);
 
     // TODO: clear/initialise data??
     if (old_capacity != new_capacity)
@@ -556,7 +556,7 @@ static void cecs_archetype_add_entity(const cecs_t* ecs, cecs_archetype_t* arche
         // Grow each component list.
         for (int i = 0; i < archetype->signature.num_components; ++i)
         {
-            cecs_component_info_t info = archetype->signature.infos[i];
+            cecs_component_info info = archetype->signature.infos[i];
 
             void* temp = realloc(archetype->columns[i],
                 new_capacity * info.size);
@@ -572,16 +572,16 @@ static void cecs_archetype_add_entity(const cecs_t* ecs, cecs_archetype_t* arche
     }
 }
 
-static void cecs_archetype_remove_entity(cecs_t* ecs, cecs_archetype_t* archetype, 
+static void cecs_archetype_remove_entity(cecs* ecs, cecs_archetype* archetype, 
     int entity_index)
 {
-    // TODO: Implement chds_vec remove functionality. Or some sort of function
+    // TODO: Implement CHDS_VEC remove functionality. Or some sort of function
     //       to do this? Removing won't really be what we want as that would
     //       shift everything rather than just quickly swapping.
 
-    int num_entities = (int)chds_vec_size(archetype->index_to_entity);
+    int num_entities = (int)CHDS_VEC_SIZE(archetype->index_to_entity);
 
-    // cecs_archetype_t already empty, should not happen.
+    // cecs_archetype already empty, should not happen.
     if (num_entities == 0)
     {
         // TODO: Handle logic error?
@@ -595,8 +595,8 @@ static void cecs_archetype_remove_entity(cecs_t* ecs, cecs_archetype_t* archetyp
     // Handle easy case of the entity being the last in the archetype.
     if (entity_index == last_entity_index)
     {
-        // TODO: chds_vec_pop_back functionality?
-        chds_vec_header_t* h = chds_vec_header(archetype->index_to_entity);
+        // TODO: CHDS_VEC_POP_BACK functionality?
+        chds_vec_header* h = CHDS_VEC_HEADER(archetype->index_to_entity);
         --h->size;
         
         return;
@@ -622,7 +622,7 @@ static void cecs_archetype_remove_entity(cecs_t* ecs, cecs_archetype_t* archetyp
     }
 
     // Update the entity we've moved's index.
-    const cecs_entity_id_t entity_to_remove = archetype->index_to_entity[last_entity_index];
+    const cecs_entity_id entity_to_remove = archetype->index_to_entity[last_entity_index];
     archetype->index_to_entity[entity_index] = entity_to_remove;
 
     // TODO: Should this ecs stuff be done elsewhere??????
@@ -632,8 +632,8 @@ static void cecs_archetype_remove_entity(cecs_t* ecs, cecs_archetype_t* archetyp
     ecs->entity_indices[entity_to_remove].archetype_id = INVALID_ARCHETYPE;
 
     // 'Remove' the last entity.
-    // TODO: chds_vec_pop_back functionality?
-    chds_vec_header_t* h = chds_vec_header(archetype->index_to_entity);
+    // TODO: CHDS_VEC_POP_BACK functionality?
+    chds_vec_header* h = CHDS_VEC_HEADER(archetype->index_to_entity);
     --h->size;
 }
 

--- a/src/ecs_internal.h
+++ b/src/ecs_internal.h
@@ -9,29 +9,29 @@
 
 typedef struct
 {
-    cecs_archetype_id_t archetype_id;
+    cecs_archetype_id archetype_id;
     int column;
-} cecs_entity_index_t;
+} cecs_entity_index;
 
-typedef struct cecs_t
+typedef struct cecs
 {
     // Entities
     int num_used_entities;
 
-    cecs_entity_id_t* free_entities;
+    cecs_entity_id* free_entities;
     int free_entities_count;
     int free_entities_capacity;
 
-    cecs_components_bitset_t* entity_components_bitsets;
+    cecs_components_bitset* entity_components_bitsets;
 
     // Stores the archetype that the entity belongs to and the position in that
     // archetype.
-    cecs_entity_index_t* entity_indices;
+    cecs_entity_index* entity_indices;
 
-    chds_vec(cecs_component_info_t) component_infos;
-    chds_vec(cecs_archetype_t) archetypes;
-    chds_vec(cecs_view_t) views;
+    CHDS_VEC(cecs_component_info) component_infos;
+    CHDS_VEC(cecs_archetype) archetypes;
+    CHDS_VEC(cecs_view) views;
 
-} cecs_t;
+} cecs;
 
 #endif

--- a/src/view.c
+++ b/src/view.c
@@ -1,6 +1,6 @@
 #include "view_internal.h"
 
-void cecs_view_destroy(cecs_view_t* view)
+void cecs_view_destroy(cecs_view* view)
 {
     // TODO: Some cecs_destroy_view should probs call this.
     chds_vec_destroy(view->archetype_ids);

--- a/src/view_internal.h
+++ b/src/view_internal.h
@@ -7,16 +7,17 @@
 
 #include <chds/vec.h>
 
-typedef struct cecs_view_t
+// TODO: should this not be like typedef struct cecs_view {} cecs_view?
+typedef struct cecs_view
 {
-    chds_vec(cecs_archetype_id_t) archetype_ids;
+    CHDS_VEC(cecs_archetype_id) archetype_ids;
 
     // TODO: Document
-    cecs_components_bitset_t include;
-    cecs_components_bitset_t exclude;
+    cecs_components_bitset include;
+    cecs_components_bitset exclude;
 
-} cecs_view_t;
+} cecs_view;
 
-void cecs_view_destroy(cecs_view_t* view);
+void cecs_view_destroy(cecs_view* view);
 
 #endif

--- a/tests/test_entity.h
+++ b/tests/test_entity.h
@@ -7,8 +7,8 @@
 
 inline void test_create()
 {
-    cecs_t* ecs = cecs_create();
-    cecs_entity_id_t e = cecs_create_entity(ecs);
+    cecs* ecs = cecs_create();
+    cecs_entity_id e = cecs_create_entity(ecs);
 
     assert(e != INVALID_ENTITY);
 }


### PR DESCRIPTION
Update previous functions like view_iter -> view_iter_create to support new convention and follow best practice of having function names include a verb.